### PR TITLE
Add NetBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ something
 nix run github:Lenivaya/qrrs "your input"
 ```
 
+## NetBSD
+```console
+pkgin install qrrs
+```
+
 ### From crates.io
 
 ```console


### PR DESCRIPTION
Hi,

I'm in the process of updating the NetBSD package to the latest release and realized I forgot to do a PR with install instructions. A package has been available since 2021-04-09.