### PR TITLE
Fix error in Nix command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ something
 ## Nix
 
 ```console
-nix run github:Lenivaya/qrrs "your input"
+nix run github:Lenivaya/qrrs -- "your input"
 ```
 
 ## NetBSD


### PR DESCRIPTION
Adds `--` between `nix run github:Lenivaya/qrrs` and program args so they get passed to the `qrrs` program and not the Nix CLI.